### PR TITLE
Add ability to initialize and use the mixer without it taking over the SDL audio callback

### DIFF
--- a/include/SDL_mixer_ext/SDL_mixer_ext.h
+++ b/include/SDL_mixer_ext/SDL_mixer_ext.h
@@ -808,11 +808,10 @@ extern DECLSPEC int SDLCALL Mix_EachSoundFont(int (SDLCALL *function)(const char
 */
 extern DECLSPEC Mix_Chunk * SDLCALL Mix_GetChunk(int channel);
 
-/* Setup the mixer with an existing AudioSpec, and without taking over the callback.
+/* Setup the mixer without taking over the callback, using an existing spec.
    These Only initialize or free the Mixer internals */
-extern DECLSPEC int SDLCALL Mix_InitMixer(const SDL_AudioSpec spec);
+extern DECLSPEC int SDLCALL Mix_InitMixer(const SDL_AudioSpec spec, SDL_bool skip_init_check);
 extern DECLSPEC void SDLCALL Mix_FreeMixer(void);
-
 
 /* Close the mixer, halting all playing audio */
 extern DECLSPEC void SDLCALL Mix_CloseAudio(void);


### PR DESCRIPTION
Wohlstand, 

When adding SDL Mixer X to dosbox,  Mix_OpenAudio(... ) takes ownership of the SDL Audio callback - preventing dosbox from outputting its own self-generated audio via its own callback - such as Adlib, Sound Blaster, and so on.

So this adds:

1. The ability to initialize SDL Mixer X without taking ownership of SDL Audio or the callback. [usage example](https://gitlab.com/krcroft/dosbox_sdl2_mixer_x/blob/master/src/hardware/mixer.cpp#L739)

2. The equivalent teardown function. [usage example](https://gitlab.com/krcroft/dosbox_sdl2_mixer_x/blob/master/src/hardware/mixer.cpp#L776)

3. The ability to "Get( ... )" the music mixer - so the calling program can access Mixer-X's decoded samples. [usage example](https://gitlab.com/krcroft/dosbox_sdl2_mixer_x/blob/master/src/dos/cdrom_image.cpp#L241)

The init and free functions could be collapsed further and share common code between the open and close functions - these are just prototypes to see what you think.

Essentially these changes make SDL Mixer less invasive on the calling program -  you can now work with it more like a library, without SDL Mixer imposing ownership over the SDL Audio device/callback.  

regards, 
 Kevin