### PR TITLE
[GetMetaTag] Added the Mix_GetMetaTag function.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,8 @@ set(AUDIO_CODECS_INSTALL_PATH "" CACHE PATH "Path to installed AudioCodecs prefi
 
 option(USE_SYSTEM_SDL2   "Use SDL2 from system" OFF)
 
+option(ENABLE_METATAG_DEBUG_PRINTOUT    "Enables printout for meta tags when loading Mix_Music" OFF)
+
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
     # Turn on warnings and legacy C/C++ standards to support more compilers
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-long-long -Wno-missing-field-initializers -std=c89")
@@ -198,6 +200,11 @@ endif()
 
 set(SDLMixerX_SOURCES)
 set(SDLMixerX_LINK_LIBS)
+
+if(ENABLE_METATAG_DEBUG_PRINTOUT)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DLOOP_DEBUG_PRINTOUT=1")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DLOOP_DEBUG_PRINTOUT=1")
+endif()
 
 include(music_wav)
 

--- a/include/SDL_mixer.h
+++ b/include/SDL_mixer.h
@@ -337,10 +337,8 @@ extern DECLSPEC const char *SDLCALL Mix_GetMusicCopyrightTag(const Mix_Music *mu
 /*
     Gets metadata from the given tag name if available
     returns NULL if this feature is not used for this music or not supported for some codec or
-    on error
-    the returned string must be freed using SDL_free after use
-    
-    This is an extension by snstruthers and is not avialable in the base SDL Mixer X library
+    on error.
+    the returned string must be freed using SDL_free after use.
 */
 extern DECLSPEC const char* SDLCALL Mix_GetMetaTag(const Mix_Music *music, const char* tag_name);
 

--- a/include/SDL_mixer.h
+++ b/include/SDL_mixer.h
@@ -334,6 +334,16 @@ extern DECLSPEC const char *SDLCALL Mix_GetMusicAlbumTag(const Mix_Music *music)
 /* Get music copyright from meta-tag if possible */
 extern DECLSPEC const char *SDLCALL Mix_GetMusicCopyrightTag(const Mix_Music *music);
 
+/*
+    Gets metadata from the given tag name if available
+    returns NULL if this feature is not used for this music or not supported for some codec or
+    on error
+    the returned string must be freed using SDL_free after use
+    
+    This is an extension by snstruthers and is not avialable in the base SDL Mixer X library
+*/
+extern DECLSPEC const char* SDLCALL Mix_GetMetaTag(const Mix_Music *music, const char* tag_name);
+
 /* Set a function that is called after all mixing is performed.
    This can be used to provide real-time visual display of the audio stream
    or add a custom mixer filter for the stream data.

--- a/src/codecs/music_cmd.c
+++ b/src/codecs/music_cmd.c
@@ -290,6 +290,7 @@ Mix_MusicInterface Mix_MusicInterface_CMD =
     NULL,   /* LoopEnd [MIXER-X]*/
     NULL,   /* LoopLength [MIXER-X]*/
     NULL,   /* GetMetaTag [MIXER-X]*/
+    NULL,   /* GetUserTag [MIXER-X-snstruthers]*/
     MusicCMD_Pause,
     MusicCMD_Resume,
     MusicCMD_Stop,

--- a/src/codecs/music_cmd.c
+++ b/src/codecs/music_cmd.c
@@ -290,7 +290,7 @@ Mix_MusicInterface Mix_MusicInterface_CMD =
     NULL,   /* LoopEnd [MIXER-X]*/
     NULL,   /* LoopLength [MIXER-X]*/
     NULL,   /* GetMetaTag [MIXER-X]*/
-    NULL,   /* GetUserTag [MIXER-X-snstruthers]*/
+    NULL,   /* GetUserTag [MIXER-X]*/
     MusicCMD_Pause,
     MusicCMD_Resume,
     MusicCMD_Stop,

--- a/src/codecs/music_flac.c
+++ b/src/codecs/music_flac.c
@@ -849,7 +849,7 @@ Mix_MusicInterface Mix_MusicInterface_FLAC =
     FLAC_LoopEnd,/* LoopEnd [MIXER-X]*/
     FLAC_LoopLength,/* LoopLength [MIXER-X]*/
     FLAC_GetMetaTag,/* GetMetaTag [MIXER-X]*/
-    FLAC_GetUserTag,/* GetUserTag [MIXER-X-snstruthers]*/
+    FLAC_GetUserTag,/* GetUserTag [MIXER-X]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     NULL,   /* Stop */

--- a/src/codecs/music_fluidsynth.c
+++ b/src/codecs/music_fluidsynth.c
@@ -325,7 +325,7 @@ Mix_MusicInterface Mix_MusicInterface_FLUIDSYNTH =
     NULL,   /* LoopEnd [MIXER-X]*/
     NULL,   /* LoopLength [MIXER-X]*/
     NULL,   /* GetMetaTag [MIXER-X]*/
-    NULL,   /* GetUserTag [MIXER-X-snstruthers]*/
+    NULL,   /* GetUserTag [MIXER-X]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     FLUIDSYNTH_Stop,

--- a/src/codecs/music_fluidsynth.c
+++ b/src/codecs/music_fluidsynth.c
@@ -325,6 +325,7 @@ Mix_MusicInterface Mix_MusicInterface_FLUIDSYNTH =
     NULL,   /* LoopEnd [MIXER-X]*/
     NULL,   /* LoopLength [MIXER-X]*/
     NULL,   /* GetMetaTag [MIXER-X]*/
+    NULL,   /* GetUserTag [MIXER-X-snstruthers]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     FLUIDSYNTH_Stop,

--- a/src/codecs/music_gme.c
+++ b/src/codecs/music_gme.c
@@ -547,6 +547,7 @@ Mix_MusicInterface Mix_MusicInterface_GME =
     NULL,   /* LoopEnd [MIXER-X]*/
     NULL,   /* LoopLength [MIXER-X]*/
     GME_GetMetaTag,/* GetMetaTag [MIXER-X]*/
+    NULL,   /* GetUserTa [MIXER-X-snstruthers]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     NULL,   /* Stop */

--- a/src/codecs/music_gme.c
+++ b/src/codecs/music_gme.c
@@ -547,7 +547,7 @@ Mix_MusicInterface Mix_MusicInterface_GME =
     NULL,   /* LoopEnd [MIXER-X]*/
     NULL,   /* LoopLength [MIXER-X]*/
     GME_GetMetaTag,/* GetMetaTag [MIXER-X]*/
-    NULL,   /* GetUserTa [MIXER-X-snstruthers]*/
+    NULL,   /* GetUserTa [MIXER-X]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     NULL,   /* Stop */

--- a/src/codecs/music_mad.c
+++ b/src/codecs/music_mad.c
@@ -676,7 +676,7 @@ Mix_MusicInterface Mix_MusicInterface_MAD =
     NULL,   /* LoopEnd [MIXER-X]*/
     NULL,   /* LoopLength [MIXER-X]*/
     MAD_GetMetaTag, /* GetMetaTag [MIXER-X]*/
-    NULL,   /* GetUserTag [MIXER-X-snstruthers]*/
+    NULL,   /* GetUserTag [MIXER-X]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     NULL,   /* Stop */

--- a/src/codecs/music_mad.c
+++ b/src/codecs/music_mad.c
@@ -676,6 +676,7 @@ Mix_MusicInterface Mix_MusicInterface_MAD =
     NULL,   /* LoopEnd [MIXER-X]*/
     NULL,   /* LoopLength [MIXER-X]*/
     MAD_GetMetaTag, /* GetMetaTag [MIXER-X]*/
+    NULL,   /* GetUserTag [MIXER-X-snstruthers]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     NULL,   /* Stop */

--- a/src/codecs/music_midi_adl.c
+++ b/src/codecs/music_midi_adl.c
@@ -965,7 +965,7 @@ Mix_MusicInterface Mix_MusicInterface_ADLIMF =
     ADLMIDI_LoopEnd,   /* LoopEnd [MIXER-X]*/
     ADLMIDI_LoopLength,   /* LoopLength [MIXER-X]*/
     ADLMIDI_GetMetaTag,   /* GetMetaTag [MIXER-X]*/
-    NULL,   /* GetUserTag [MIXER-X-snstruthers]*/
+    NULL,   /* GetUserTag [MIXER-X]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     NULL,   /* Stop */

--- a/src/codecs/music_midi_adl.c
+++ b/src/codecs/music_midi_adl.c
@@ -965,6 +965,7 @@ Mix_MusicInterface Mix_MusicInterface_ADLIMF =
     ADLMIDI_LoopEnd,   /* LoopEnd [MIXER-X]*/
     ADLMIDI_LoopLength,   /* LoopLength [MIXER-X]*/
     ADLMIDI_GetMetaTag,   /* GetMetaTag [MIXER-X]*/
+    NULL,   /* GetUserTag [MIXER-X-snstruthers]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     NULL,   /* Stop */

--- a/src/codecs/music_midi_opn.c
+++ b/src/codecs/music_midi_opn.c
@@ -765,7 +765,7 @@ Mix_MusicInterface Mix_MusicInterface_OPNMIDI =
     OPNMIDI_LoopEnd,   /* LoopEnd [MIXER-X]*/
     OPNMIDI_LoopLength,   /* LoopLength [MIXER-X]*/
     OPNMIDI_GetMetaTag,   /* GetMetaTag [MIXER-X]*/
-    NULL,   /* GetUserTag [MIXER-X-snstruthers]*/
+    NULL,   /* GetUserTag [MIXER-X]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     NULL,   /* Stop */

--- a/src/codecs/music_midi_opn.c
+++ b/src/codecs/music_midi_opn.c
@@ -765,6 +765,7 @@ Mix_MusicInterface Mix_MusicInterface_OPNMIDI =
     OPNMIDI_LoopEnd,   /* LoopEnd [MIXER-X]*/
     OPNMIDI_LoopLength,   /* LoopLength [MIXER-X]*/
     OPNMIDI_GetMetaTag,   /* GetMetaTag [MIXER-X]*/
+    NULL,   /* GetUserTag [MIXER-X-snstruthers]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     NULL,   /* Stop */

--- a/src/codecs/music_mikmod.c
+++ b/src/codecs/music_mikmod.c
@@ -511,7 +511,7 @@ Mix_MusicInterface Mix_MusicInterface_MIKMOD =
     NULL,   /* LoopEnd [MIXER-X]*/
     NULL,   /* LoopLength [MIXER-X]*/
     MIKMOD_GetMetaTag,/* GetMetaTag [MIXER-X]*/
-    NULL,   /* GetUserTag [MIXER-X-snstruthers]*/
+    NULL,   /* GetUserTag [MIXER-X]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     MIKMOD_Stop,

--- a/src/codecs/music_mikmod.c
+++ b/src/codecs/music_mikmod.c
@@ -511,6 +511,7 @@ Mix_MusicInterface Mix_MusicInterface_MIKMOD =
     NULL,   /* LoopEnd [MIXER-X]*/
     NULL,   /* LoopLength [MIXER-X]*/
     MIKMOD_GetMetaTag,/* GetMetaTag [MIXER-X]*/
+    NULL,   /* GetUserTag [MIXER-X-snstruthers]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     MIKMOD_Stop,

--- a/src/codecs/music_modplug.c
+++ b/src/codecs/music_modplug.c
@@ -359,7 +359,7 @@ Mix_MusicInterface Mix_MusicInterface_MODPLUG =
     NULL,   /* LoopEnd [MIXER-X]*/
     NULL,   /* LoopLength [MIXER-X]*/
     MODPLUG_GetMetaTag, /* GetMetaTag [MIXER-X]*/
-    NULL,   /* GetUserTag [MIXER-X-snstruthers]*/
+    NULL,   /* GetUserTag [MIXER-X]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     NULL,   /* Stop */

--- a/src/codecs/music_modplug.c
+++ b/src/codecs/music_modplug.c
@@ -359,6 +359,7 @@ Mix_MusicInterface Mix_MusicInterface_MODPLUG =
     NULL,   /* LoopEnd [MIXER-X]*/
     NULL,   /* LoopLength [MIXER-X]*/
     MODPLUG_GetMetaTag, /* GetMetaTag [MIXER-X]*/
+    NULL,   /* GetUserTag [MIXER-X-snstruthers]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     NULL,   /* Stop */

--- a/src/codecs/music_mpg123.c
+++ b/src/codecs/music_mpg123.c
@@ -517,6 +517,7 @@ Mix_MusicInterface Mix_MusicInterface_MPG123 =
     NULL,   /* LoopEnd [MIXER-X]*/
     NULL,   /* LoopLength [MIXER-X]*/
     MPG123_GetMetaTag,/* GetMetaTag [MIXER-X]*/
+    NULL,   /* GetUserTag [MIXER-X-snstruthers]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     NULL,   /* Stop */

--- a/src/codecs/music_mpg123.c
+++ b/src/codecs/music_mpg123.c
@@ -517,7 +517,7 @@ Mix_MusicInterface Mix_MusicInterface_MPG123 =
     NULL,   /* LoopEnd [MIXER-X]*/
     NULL,   /* LoopLength [MIXER-X]*/
     MPG123_GetMetaTag,/* GetMetaTag [MIXER-X]*/
-    NULL,   /* GetUserTag [MIXER-X-snstruthers]*/
+    NULL,   /* GetUserTag [MIXER-X]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     NULL,   /* Stop */

--- a/src/codecs/music_nativemidi.c
+++ b/src/codecs/music_nativemidi.c
@@ -111,7 +111,7 @@ Mix_MusicInterface Mix_MusicInterface_NATIVEMIDI =
     NULL,   /* LoopEnd [MIXER-X]*/
     NULL,   /* LoopLength [MIXER-X]*/
     NULL,   /* GetMetaTag [MIXER-X]*/
-    NULL,   /* GetUserTag [MIXER-X-snstruthers]*/
+    NULL,   /* GetUserTag [MIXER-X]*/
     NATIVEMIDI_Pause,
     NATIVEMIDI_Resume,
     NATIVEMIDI_Stop,

--- a/src/codecs/music_nativemidi.c
+++ b/src/codecs/music_nativemidi.c
@@ -111,6 +111,7 @@ Mix_MusicInterface Mix_MusicInterface_NATIVEMIDI =
     NULL,   /* LoopEnd [MIXER-X]*/
     NULL,   /* LoopLength [MIXER-X]*/
     NULL,   /* GetMetaTag [MIXER-X]*/
+    NULL,   /* GetUserTag [MIXER-X-snstruthers]*/
     NATIVEMIDI_Pause,
     NATIVEMIDI_Resume,
     NATIVEMIDI_Stop,

--- a/src/codecs/music_ogg.c
+++ b/src/codecs/music_ogg.c
@@ -638,7 +638,7 @@ Mix_MusicInterface Mix_MusicInterface_OGG =
     OGG_LoopEnd,   /* LoopEnd [MIXER-X]*/
     OGG_LoopLength,   /* LoopLength [MIXER-X]*/
     OGG_GetMetaTag,   /* GetMetaTag [MIXER-X]*/
-    OGG_GetUserTag,   /* GetUserTag [MIXER-X-snstruthers]*/
+    OGG_GetUserTag,   /* GetUserTag [MIXER-X]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     NULL,   /* Stop */

--- a/src/codecs/music_opus.c
+++ b/src/codecs/music_opus.c
@@ -609,7 +609,7 @@ Mix_MusicInterface Mix_MusicInterface_Opus =
     OPUS_LoopEnd, /* LoopEnd [MIXER-X]*/
     OPUS_LoopLength, /* LoopLength [MIXER-X]*/
     OPUS_GetMetaTag, /* GetMetaTag [MIXER-X]*/
-    OPUS_GetUserTag, /* GetUserTag [MIXER-X-snstruthers]*/
+    OPUS_GetUserTag, /* GetUserTag [MIXER-X]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     NULL,   /* Stop */

--- a/src/codecs/music_timidity.c
+++ b/src/codecs/music_timidity.c
@@ -286,7 +286,7 @@ Mix_MusicInterface Mix_MusicInterface_TIMIDITY =
     NULL,   /* LoopEnd [MIXER-X]*/
     NULL,   /* LoopLength [MIXER-X]*/
     NULL,   /* GetMetaTag [MIXER-X]*/
-    NULL,   /* GetUserTag [MIXER-X-snstruthers]*/
+    NULL,   /* GetUserTag [MIXER-X]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     NULL,   /* Stop */

--- a/src/codecs/music_timidity.c
+++ b/src/codecs/music_timidity.c
@@ -286,6 +286,7 @@ Mix_MusicInterface Mix_MusicInterface_TIMIDITY =
     NULL,   /* LoopEnd [MIXER-X]*/
     NULL,   /* LoopLength [MIXER-X]*/
     NULL,   /* GetMetaTag [MIXER-X]*/
+    NULL,   /* GetUserTag [MIXER-X-snstruthers]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     NULL,   /* Stop */

--- a/src/codecs/music_wav.c
+++ b/src/codecs/music_wav.c
@@ -1246,6 +1246,7 @@ Mix_MusicInterface Mix_MusicInterface_WAV =
     NULL,   /* LoopEnd [MIXER-X]*/
     NULL,   /* LoopLength [MIXER-X]*/
     WAV_GetMetaTag,   /* GetMetaTag [MIXER-X]*/
+    NULL,   /* GetUserTag [MIXER-X-snstruthers]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     NULL,   /* Stop */

--- a/src/codecs/music_wav.c
+++ b/src/codecs/music_wav.c
@@ -1246,7 +1246,7 @@ Mix_MusicInterface Mix_MusicInterface_WAV =
     NULL,   /* LoopEnd [MIXER-X]*/
     NULL,   /* LoopLength [MIXER-X]*/
     WAV_GetMetaTag,   /* GetMetaTag [MIXER-X]*/
-    NULL,   /* GetUserTag [MIXER-X-snstruthers]*/
+    NULL,   /* GetUserTag [MIXER-X]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     NULL,   /* Stop */

--- a/src/codecs/music_xmp.c
+++ b/src/codecs/music_xmp.c
@@ -404,7 +404,7 @@ Mix_MusicInterface Mix_MusicInterface_LIBXMP =
     NULL,   /* LoopEnd [MIXER-X] */
     NULL,   /* LoopLength [MIXER-X]*/
     XMP_GetMetaTag, /* GetMetaTag [MIXER-X]*/
-    NULL, /* GetUserTag [MIXER-X-snstruthers]*/
+    NULL, /* GetUserTag [MIXER-X]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     NULL,   /* Stop */

--- a/src/codecs/music_xmp.c
+++ b/src/codecs/music_xmp.c
@@ -404,6 +404,7 @@ Mix_MusicInterface Mix_MusicInterface_LIBXMP =
     NULL,   /* LoopEnd [MIXER-X] */
     NULL,   /* LoopLength [MIXER-X]*/
     XMP_GetMetaTag, /* GetMetaTag [MIXER-X]*/
+    NULL, /* GetUserTag [MIXER-X-snstruthers]*/
     NULL,   /* Pause */
     NULL,   /* Resume */
     NULL,   /* Stop */

--- a/src/music.c
+++ b/src/music.c
@@ -1356,6 +1356,25 @@ const char *SDLCALLCC Mix_GetMusicCopyrightTag(const Mix_Music *music)
     return get_music_tag_internal(music, MIX_META_COPYRIGHT);
 }
 
+const char *SDLCALLCC Mix_GetMetaTag(const Mix_Music *music, const char* tag_name)
+{
+    if (!tag_name)
+        return NULL;
+    
+    const char *tag = NULL;
+
+    Mix_LockAudio();
+    if (music && music->interface->GetUserTag) {
+        tag = music->interface->GetUserTag(music->context, tag_name);
+    } else if (music_playing && music_playing->interface->GetUserTag) {
+        tag = music_playing->interface->GetUserTag(music_playing->context, tag_name);
+    } else {
+        Mix_SetError("Music isn't playing");
+    }
+    Mix_UnlockAudio();
+    return tag;
+}
+
 /* Play a music chunk.  Returns 0, or -1 if there was an error.
  */
 static int music_internal_play(Mix_Music *music, int play_count, double position)

--- a/src/music.h
+++ b/src/music.h
@@ -23,9 +23,6 @@
 #ifndef MUSIC_H_
 #define MUSIC_H_
 
-#define LOOP_DEBUG_PRINTOUT 1
-/*#define LOOP_DEBUG_PRINTOUT 0*/
-
 /* Supported music APIs, in order of preference */
 
 typedef enum
@@ -153,7 +150,7 @@ typedef struct
     /* MIXER-X: Get a meta-tag string if available */
     const char* (*GetMetaTag)(void *music, Mix_MusicMetaTag tag_type);
     
-    /* MIXER-X (snstruthers): Get an arbitrary meta-tag string if available */
+    /* MIXER-X: Get an arbitrary meta-tag string if available */
     const char* (*GetUserTag)(void *music, const char* tag_name);
 
     /* Pause playing music */

--- a/src/music.h
+++ b/src/music.h
@@ -23,6 +23,9 @@
 #ifndef MUSIC_H_
 #define MUSIC_H_
 
+#define LOOP_DEBUG_PRINTOUT 1
+/*#define LOOP_DEBUG_PRINTOUT 0*/
+
 /* Supported music APIs, in order of preference */
 
 typedef enum
@@ -57,7 +60,6 @@ typedef enum
     MIX_META_COPYRIGHT,
     MIX_META_LAST
 } Mix_MusicMetaTag;
-
 
 /* MIXER-X: Meta-tags utility structure */
 
@@ -150,6 +152,9 @@ typedef struct
 
     /* MIXER-X: Get a meta-tag string if available */
     const char* (*GetMetaTag)(void *music, Mix_MusicMetaTag tag_type);
+    
+    /* MIXER-X (snstruthers): Get an arbitrary meta-tag string if available */
+    const char* (*GetUserTag)(void *music, const char* tag_name);
 
     /* Pause playing music */
     void (*Pause)(void *music);


### PR DESCRIPTION
A quick-and-dirty way to get meta tags from a Mix_Music pointer. I added it for a project I'm working on.