### PR TITLE
Mix_LoadWAV_RW: shrink buffer after conversion to mixer format

### DIFF
--- a/src/mixer.c
+++ b/src/mixer.c
@@ -909,8 +909,7 @@ Mix_Chunk * MIXCALLCC Mix_LoadWAV_RW(SDL_RWops *src, int freesrc)
             if(!chunk->abuf) {
                 chunk->abuf = wavecvt.buf;
             }
-        }
-        else {
+        } else {
             chunk->abuf = wavecvt.buf;
         }
 

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -901,7 +901,19 @@ Mix_Chunk * MIXCALLCC Mix_LoadWAV_RW(SDL_RWops *src, int freesrc)
             return(NULL);
         }
 
-        chunk->abuf = wavecvt.buf;
+        /* Shrink buffer if appropriate, otherwise reuse directly */
+        if (wavecvt.len_cvt != wavecvt.len) {
+            chunk->abuf = (Uint8 *)SDL_realloc(wavecvt.buf, wavecvt.len_cvt);
+
+            /* Reuse buffer directly on realloc failure */
+            if(!chunk->abuf) {
+                chunk->abuf = wavecvt.buf;
+            }
+        }
+        else {
+            chunk->abuf = wavecvt.buf;
+        }
+
         chunk->alen = wavecvt.len_cvt;
     }
 


### PR DESCRIPTION
PR to address some memory usage issues on homebrew platforms.

Mix_LoadWAV_RW allocates a large conversion buffer (up to 4x the final audio chunk size) and never shrinks it after loading. This is acceptable on systems with virtual memory (can just page the unused space out) but unacceptable on homebrew platforms like 3DS and Wii which both have very limited RAM.

I'm not very familiar with the realloc method, so it's possible there's a better way of getting the same effect here.