### PR TITLE
NativeMidi Alternative on Win32 doesn't close an opened handle used for detection

### DIFF
--- a/src/codecs/music_nativemidi_alt_win32.c
+++ b/src/codecs/music_nativemidi_alt_win32.c
@@ -277,8 +277,8 @@ int native_midi_detect(void)
     HMIDIOUT out;
     MMRESULT err = midiOutOpen(&out, 0, 0, 0, CALLBACK_NULL);
 
-    if (err == MMSYSERR_NOERROR) {
-        return -1;
+    if (err != MMSYSERR_NOERROR) {
+        return 0;
     }
 
     midiOutClose(out);

--- a/src/codecs/music_nativemidi_alt_win32.c
+++ b/src/codecs/music_nativemidi_alt_win32.c
@@ -224,7 +224,7 @@ static int init_midi_out(NativeMidiSong *seqi)
     if (err != MMSYSERR_NOERROR)
     {
         seqi->out = NULL;
-        return -1;
+        return 1;
     }
 
     for(i = 0; i < 16; i++)
@@ -315,7 +315,10 @@ static int NativeMidiThread(void *context)
         return 1;
     }
 
-    init_midi_out(music);
+    if (init_midi_out(music)) {
+      Mix_SetError("Native MIDI Win32-Alt: midiOutOpen failed (%lu)\n", (unsigned long)GetLastError());
+      return 1;
+    }
 
     midi_seq_set_loop_enabled(music->song, 1);
     midi_seq_set_loop_count(music->song, music->loops < 0 ? -1 : (music->loops + 1));


### PR DESCRIPTION
Hey there, ran into an issue with SDL_Mixer when we needed to adjust the volume of native midi independently of other sounds, so I gave SDL-Mixer-X a try due to it's alternate implementation. It was mostly smooth sailing, but I was having issues actually getting sound out.

I noticed when debugging that within `init_midi_out`, `midiOutOpen` was returning `MMSYSERR_ALLOCATED`, and not handling it as an error in `NativeMidiThread`. That led me to notice the bug in `native_midi_detect` wherein we were only closing the handle when there _was_ an error, and thus no handle would exist.

To resolve the primary issue in `native_midi_detect` all that was needed was inverting the condition. In addition I adjusted the `NativeMidiThread`s handling of errors during init. It might be that you'd _want_ to keep a handle open after detection, but I don't know how best to handle that, and given the surrounding code it seemed that the intent was just to see if one could be created, so that they could be created on demand.