### PR TITLE
Add ability to set custom path open function

### DIFF
--- a/include/SDL_mixer.h
+++ b/include/SDL_mixer.h
@@ -403,6 +403,11 @@ typedef enum {
 typedef struct Mix_Music Mix_Music;
 
 /**
+ * The type of a RWFromFile callback
+ */
+typedef SDL_RWops* (*Mix_RWFromFile_cb)(const char *file, const char *mode);
+
+/**
  * Open the default audio device for playback.
  *
  * An audio device is what generates sound, so the app must open one to make
@@ -3715,6 +3720,14 @@ extern DECLSPEC int MIXCALL Mix_InitMixer(const SDL_AudioSpec *spec, SDL_bool sk
  * This is the MixerX fork exclusive function.
  */
 extern DECLSPEC void MIXCALL Mix_FreeMixer(void);/*MixerX*/
+
+/**
+ * Set a function that MixerX will use to open RWops handles from file paths,
+ * or pass NULL to use the default SDL_RWFromFile.
+ *
+ * This is the MixerX fork exclusive function.
+ */
+extern DECLSPEC void MIXCALL Mix_SetRWFromFile(Mix_RWFromFile_cb cb);/*MixerX*/
 
 /**
  * Close the mixer, halting all playing audio.

--- a/src/codecs/music_fluidlite.c
+++ b/src/codecs/music_fluidlite.c
@@ -328,7 +328,7 @@ static void FLUIDSYNTH_Delete(void *context);
 #if 0
 static int SDLCALL fluidsynth_check_soundfont(const char *path, void *data)
 {
-    SDL_RWops *rw = SDL_RWFromFile(path, "rb");
+    SDL_RWops *rw = _Mix_RWFromFile(path, "rb");
 
     (void)data;
     if (rw) {

--- a/src/codecs/music_fluidsynth.c
+++ b/src/codecs/music_fluidsynth.c
@@ -152,7 +152,7 @@ static void FLUIDSYNTH_Delete(void *context);
 
 static int SDLCALL fluidsynth_check_soundfont(const char *path, void *data)
 {
-    SDL_RWops *rw = SDL_RWFromFile(path, "rb");
+    SDL_RWops *rw = _Mix_RWFromFile(path, "rb");
 
     (void)data;
     if (rw) {

--- a/src/codecs/music_wavpack.c
+++ b/src/codecs/music_wavpack.c
@@ -322,7 +322,7 @@ static void *WAVPACK_CreateFromFile(const char *file)
     size_t len;
     char *file2;
 
-    src1 = SDL_RWFromFile(file, "rb");
+    src1 = _Mix_RWFromFile(file, "rb");
     if (!src1) {
         Mix_SetError("Couldn't open '%s'", file);
         return NULL;
@@ -335,7 +335,7 @@ static void *WAVPACK_CreateFromFile(const char *file)
         SDL_memcpy(file2, file, len);
         file2[len] =  'c';
         file2[len + 1] = '\0';
-        src2 = SDL_RWFromFile(file2, "rb");
+        src2 = _Mix_RWFromFile(file2, "rb");
 #if WAVPACK_DBG
         if (src2) {
             SDL_Log("Loaded WavPack correction file %s", file2);

--- a/src/codecs/timidity/common.c
+++ b/src/codecs/timidity/common.c
@@ -44,7 +44,7 @@ SDL_RWops *timi_openfile(const char *name)
   /* First try the given name */
 
   SNDDBG(("Trying to open %s\n", name));
-  if ((rw = SDL_RWFromFile(name, "rb")) != NULL)
+  if ((rw = _Mix_RWFromFile(name, "rb")) != NULL)
     return rw;
 
   if (!is_abspath(name))
@@ -69,7 +69,7 @@ SDL_RWops *timi_openfile(const char *name)
 	  }
 	SDL_strlcpy(p, name, sizeof(current_filename) - l);
 	SNDDBG(("Trying to open %s\n", current_filename));
-	if ((rw = SDL_RWFromFile(current_filename, "rb")))
+	if ((rw = _Mix_RWFromFile(current_filename, "rb")))
 	  return rw;
 	plp = plp->next;
       }

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -1521,8 +1521,7 @@ void MIXCALLCC Mix_SetRWFromFile(Mix_RWFromFile_cb cb)
 {
     if (cb) {
         _Mix_RWFromFile = cb;
-    }
-    else {
+    } else {
         _Mix_RWFromFile = SDL_RWFromFile;
     }
 }

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -59,6 +59,8 @@ SDL_COMPILE_TIME_ASSERT(SDL_MIXER_PATCHLEVEL_min, SDL_MIXER_PATCHLEVEL >= 0);
 SDL_COMPILE_TIME_ASSERT(SDL_MIXER_PATCHLEVEL_max, SDL_MIXER_PATCHLEVEL <= 99);
 #endif
 
+Mix_RWFromFile_cb _Mix_RWFromFile = SDL_RWFromFile;
+
 static int audio_opened = 0;
 static SDL_AudioSpec mixer;
 static SDL_AudioDeviceID audio_device;
@@ -949,7 +951,7 @@ Mix_Chunk * MIXCALLCC Mix_LoadWAV_RW(SDL_RWops *src, int freesrc)
 
 Mix_Chunk * MIXCALLCC Mix_LoadWAV(const char *file)
 {
-    return Mix_LoadWAV_RW(SDL_RWFromFile(file, "rb"), 1);
+    return Mix_LoadWAV_RW(_Mix_RWFromFile(file, "rb"), 1);
 }
 
 /* Load a wave file of the mixer format from a memory buffer */
@@ -1506,6 +1508,22 @@ void MIXCALLCC Mix_FreeMixer(void)
             num_decoders = 0;
         }
         --audio_opened;
+    }
+}
+
+/**
+ * Set a function that MixerX will use to open RWops handles from file paths,
+ * or pass NULL to use the default SDL_RWFromFile.
+ *
+ * This is the MixerX fork exclusive function.
+ */
+void MIXCALLCC Mix_SetRWFromFile(Mix_RWFromFile_cb cb)
+{
+    if (cb) {
+        _Mix_RWFromFile = cb;
+    }
+    else {
+        _Mix_RWFromFile = SDL_RWFromFile;
     }
 }
 

--- a/src/mixer.h
+++ b/src/mixer.h
@@ -21,11 +21,15 @@
 #ifndef MIXER_H_
 #define MIXER_H_
 
+typedef SDL_RWops* (*Mix_RWFromFile_cb)(const char *file, const char *mode);
+
 /* Locking wrapper functions */
 extern void Mix_LockAudio(void);
 extern void Mix_UnlockAudio(void);
 
 extern void add_chunk_decoder(const char *decoder);
+
+extern Mix_RWFromFile_cb _Mix_RWFromFile;
 
 #endif /* MIXER_H_ */
 

--- a/src/music.c
+++ b/src/music.c
@@ -1887,7 +1887,7 @@ Mix_Music * MIXCALLCC Mix_LoadMUS(const char *file)
         }
     }
 
-    src = SDL_RWFromFile(file, "rb");
+    src = _Mix_RWFromFile(file, "rb");
     if (src == NULL) {
         Mix_SetError("Couldn't open '%s'", file);
         SDL_free(music_file);
@@ -3435,7 +3435,7 @@ const char* MIXCALLCC Mix_GetSoundFonts(void)
         unsigned i;
 
         for (i = 0; i < SDL_arraysize(s_soundfont_paths); ++i) {
-            SDL_RWops *rwops = SDL_RWFromFile(s_soundfont_paths[i], "rb");
+            SDL_RWops *rwops = _Mix_RWFromFile(s_soundfont_paths[i], "rb");
             if (rwops) {
                 SDL_RWclose(rwops);
                 return s_soundfont_paths[i];


### PR DESCRIPTION
This PR allows client applications (such as TheXTech) to set all path opens inside MixerX to go through client application code. This has two advantages:

(1) allows MixerX's filetype-detect code to use filename hints even if the client application is using a virtual filesystem layer
(2) allows MixerX to open dependent file paths (such as soundfonts) even if the client application is using a virtual filesystem layer